### PR TITLE
fix: fleet run doc

### DIFF
--- a/ag2-py/README.md
+++ b/ag2-py/README.md
@@ -66,50 +66,18 @@ Follow these steps to set up and run the app locally.
    ```bash
    docker pull sparsityxyz/fleet:latest
    ```
-   b) Initialize Fleet:
+   d) Run Fleet:
    ```bash
    # macOS
    docker run -ti --rm \
-       -v ./.data:/root/.fleet \
        -v /var/run/docker.sock:/var/run/docker.sock \
-       sparsityxyz/fleet:latest fleet init --local
+       sparsityxyz/fleet:latest fleet run --local
 
    # Linux
    docker run -ti --rm \
-       -v ./.data:/root/.fleet \
        -v /var/run/docker.sock:/var/run/docker.sock \
        --add-host=host.docker.internal:172.17.0.1 \
-       sparsityxyz/fleet:latest fleet init --local
-   ```
-   c) Register Fleet:
-   ```bash
-   # macOS
-   docker run -ti --rm \
-       -v ./.data:/root/.fleet \
-       -v /var/run/docker.sock:/var/run/docker.sock \
-       sparsityxyz/fleet:latest fleet register --ip 127.0.0.1
-
-   # Linux
-   docker run -ti --rm \
-       -v ./.data:/root/.fleet \
-       -v /var/run/docker.sock:/var/run/docker.sock \
-       --add-host=host.docker.internal:172.17.0.1 \
-       sparsityxyz/fleet:latest fleet register --ip 127.0.0.1
-   ```
-   d) Run Fleet (whitelisting two addresses):
-   ```bash
-   # macOS
-   docker run -ti --rm \
-       -v ./.data:/root/.fleet \
-       -v /var/run/docker.sock:/var/run/docker.sock \
-       sparsityxyz/fleet:latest fleet run
-
-   # Linux
-   docker run -ti --rm \
-       -v ./.data:/root/.fleet \
-       -v /var/run/docker.sock:/var/run/docker.sock \
-       --add-host=host.docker.internal:172.17.0.1 \
-       sparsityxyz/fleet:latest fleet run
+       sparsityxyz/fleet:latest fleet run --local
    ```
 
 ### 5. Start the Client  

--- a/fibonacci-js/README.md
+++ b/fibonacci-js/README.md
@@ -56,55 +56,19 @@ docker pull sparsityxyz/fleet:latest
 docker pull sparsityxyz/fleet-er:latest
 ```  
 
-#### Initialize Fleet  
-
-```bash
-# macOS
-docker run -ti --rm \
-    -v ./.data:/root/.fleet \
-    -v /var/run/docker.sock:/var/run/docker.sock \
-    sparsityxyz/fleet:latest fleet init --local
-
-# Linux
-docker run -ti --rm \
-    -v ./.data:/root/.fleet \
-    -v /var/run/docker.sock:/var/run/docker.sock \
-    --add-host=host.docker.internal:172.17.0.1 \
-    sparsityxyz/fleet:latest fleet init --local
-```  
-
-#### Register Fleet  
-
-```bash
-# macOS
-docker run -ti --rm \
-    -v ./.data:/root/.fleet \
-    -v /var/run/docker.sock:/var/run/docker.sock \
-    sparsityxyz/fleet:latest fleet register --ip 127.0.0.1
-
-# Linux
-docker run -ti --rm \
-    -v ./.data:/root/.fleet \
-    -v /var/run/docker.sock:/var/run/docker.sock \
-    --add-host=host.docker.internal:172.17.0.1 \
-    sparsityxyz/fleet:latest fleet register --ip 127.0.0.1
-```  
-
 #### Run Fleet  
 
 ```bash
 # macOS
 docker run -ti --rm \
-    -v ./.data:/root/.fleet \
     -v /var/run/docker.sock:/var/run/docker.sock \
-    sparsityxyz/fleet:latest fleet run
+    sparsityxyz/fleet:latest fleet run --local
 
 # Linux
 docker run -ti --rm \
-    -v ./.data:/root/.fleet \
     -v /var/run/docker.sock:/var/run/docker.sock \
     --add-host=host.docker.internal:172.17.0.1 \
-    sparsityxyz/fleet:latest fleet run
+    sparsityxyz/fleet:latest fleet run --local
 ```  
 
 ### 5. Interact with the Smart Contract  

--- a/fibonacci-py/README.md
+++ b/fibonacci-py/README.md
@@ -56,55 +56,19 @@ docker pull sparsityxyz/fleet:latest
 docker pull sparsityxyz/fleet-er:latest
 ```  
 
-#### Initialize Fleet  
-
-```bash
-# macOS
-docker run -ti --rm \
-    -v ./.data:/root/.fleet \
-    -v /var/run/docker.sock:/var/run/docker.sock \
-    sparsityxyz/fleet:latest fleet init --local
-
-# Linux
-docker run -ti --rm \
-    -v ./.data:/root/.fleet \
-    -v /var/run/docker.sock:/var/run/docker.sock \
-    --add-host=host.docker.internal:172.17.0.1 \
-    sparsityxyz/fleet:latest fleet init --local
-```  
-
-#### Register Fleet  
-
-```bash
-# macOS
-docker run -ti --rm \
-    -v ./.data:/root/.fleet \
-    -v /var/run/docker.sock:/var/run/docker.sock \
-    sparsityxyz/fleet:latest fleet register --ip 127.0.0.1
-
-# Linux
-docker run -ti --rm \
-    -v ./.data:/root/.fleet \
-    -v /var/run/docker.sock:/var/run/docker.sock \
-    --add-host=host.docker.internal:172.17.0.1 \
-    sparsityxyz/fleet:latest fleet register --ip 127.0.0.1
-```  
-
 #### Run Fleet  
 
 ```bash
 # macOS
 docker run -ti --rm \
-    -v ./.data:/root/.fleet \
     -v /var/run/docker.sock:/var/run/docker.sock \
-    sparsityxyz/fleet:latest fleet run
+    sparsityxyz/fleet:latest fleet run --local
 
 # Linux
 docker run -ti --rm \
-    -v ./.data:/root/.fleet \
     -v /var/run/docker.sock:/var/run/docker.sock \
     --add-host=host.docker.internal:172.17.0.1 \
-    sparsityxyz/fleet:latest fleet run
+    sparsityxyz/fleet:latest fleet run --local
 ```  
 
 ### 5. Interact with the Smart Contract  

--- a/gomoku-js/README.md
+++ b/gomoku-js/README.md
@@ -62,50 +62,18 @@ Follow these steps to set up and run the app locally.
    docker pull sparsityxyz/fleet:latest
    docker pull sparsityxyz/fleet-er:latest
    ```
-   b) Initialize Fleet:
+   b) Run Fleet:
    ```bash
    # macOS
    docker run -ti --rm \
-       -v ./.data:/root/.fleet \
        -v /var/run/docker.sock:/var/run/docker.sock \
-       sparsityxyz/fleet:latest fleet init --local
+       sparsityxyz/fleet:latest fleet run --local
 
    # Linux
    docker run -ti --rm \
-       -v ./.data:/root/.fleet \
        -v /var/run/docker.sock:/var/run/docker.sock \
        --add-host=host.docker.internal:172.17.0.1 \
-       sparsityxyz/fleet:latest fleet init --local
-   ```
-   c) Register Fleet:
-   ```bash
-   # macOS
-   docker run -ti --rm \
-       -v ./.data:/root/.fleet \
-       -v /var/run/docker.sock:/var/run/docker.sock \
-       sparsityxyz/fleet:latest fleet register --ip 127.0.0.1
-
-   # Linux
-   docker run -ti --rm \
-       -v ./.data:/root/.fleet \
-       -v /var/run/docker.sock:/var/run/docker.sock \
-       --add-host=host.docker.internal:172.17.0.1 \
-       sparsityxyz/fleet:latest fleet register --ip 127.0.0.1
-   ```
-   d) Run Fleet:
-   ```bash
-   # macOS
-   docker run -ti --rm \
-       -v ./.data:/root/.fleet \
-       -v /var/run/docker.sock:/var/run/docker.sock \
-       sparsityxyz/fleet:latest fleet run 
-
-   # Linux
-   docker run -ti --rm \
-       -v ./.data:/root/.fleet \
-       -v /var/run/docker.sock:/var/run/docker.sock \
-       --add-host=host.docker.internal:172.17.0.1 \
-       sparsityxyz/fleet:latest fleet run  
+       sparsityxyz/fleet:latest fleet run --local
    ```
 
 ### 5. Start the Client  


### PR DESCRIPTION
Now we can run fleet in one command:
```
# macOS
docker run -ti --rm \
   -v /var/run/docker.sock:/var/run/docker.sock \
   sparsityxyz/fleet:latest fleet run --local

# Linux
docker run -ti --rm \
   -v /var/run/docker.sock:/var/run/docker.sock \
   --add-host=host.docker.internal:172.17.0.1 \
   sparsityxyz/fleet:latest fleet run --local
```